### PR TITLE
記事一覧のTop説明文とページ番号の軽微な修正

### DIFF
--- a/mysite/blog/static/css/blog_index_page.css
+++ b/mysite/blog/static/css/blog_index_page.css
@@ -168,17 +168,21 @@ h2 {
   justify-content: center;
   align-items: baseline;
 }
+
+.page a {
+  color: #625651;
+  text-decoration: none;
+}
+
 .page-number {
   padding: 20px;
-  color: #625651;
 }
+
 .page-number:hover {
   background-color: RGB(98, 86, 81,0.5);
   color: #fff;
   border-radius: 50px;
-  /* transition: ease-in-out 0.1s; */
   transition: 0.1s;
-  text-decoration: none;
   padding: 20px;
   width: 20px;
   height: 20px;
@@ -192,7 +196,6 @@ h2 {
   background-color: #edcf3b;
   box-shadow: 0 3px 3px rgba(0, 0, 0, 0.25);
   border-radius: 30px;
-  text-decoration: none;
 }
 .page-prev {
   margin-right: 20px;
@@ -206,13 +209,11 @@ h2 {
   background-color: #ffdf42;
   box-shadow: 0 3px 3px rgba(0, 0, 0, 0.25);
   border-radius: 30px;
-  text-decoration: none;
 }
 .current {
   background-color: #625651;
   color: #fff !important;
   border-radius: 50px;
-  text-decoration: none;
   padding: 20px;
   width:20px;
   height:20px;

--- a/mysite/blog/templates/blog/blog_index_page.html
+++ b/mysite/blog/templates/blog/blog_index_page.html
@@ -4,11 +4,8 @@
 {% block content %}
 <link rel="stylesheet" href="{% static 'css/blog_index_page.css' %}">
   <div class="container">
-    <h2>Scrollは、HAGAKUREプログラミング塾の参加者が運営するブログサイトです。<br>
-        日々の学びや成果、失敗談、そして佐賀に関する情報を共有する場として活用されています。<br>
-        「HAGAKURE（葉隠）」は、江戸時代に佐賀藩士が著した武士の心得を説く書物です。<br>
+    <h2>Scrollは、HAGAKUREプログラミング塾の参加者が運営するブログサイトです。
     </h2>
-
     <div class="wrapper">
       {% for article in blogpages %}
       <article class="article">


### PR DESCRIPTION
以下、修正しました。
・記事一覧のTopにScrollの説明文を３行→１行へ修正
・ページ番号と「前へ戻る」「次のページへ」のリンクについは、下線表示なし、色は#625651へ